### PR TITLE
fix(vercel): remove functions block to avoid conflict with builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -35,10 +35,5 @@
   ],
   "env": {
     "NODE_ENV": "production"
-  },
-  "functions": {
-    "server/index.ts": {
-      "maxDuration": 30
-    }
   }
 }


### PR DESCRIPTION
Vercel error: 'functions' no puede coexistir con 'builds'. Se elimina 'functions' manteniendo 'builds' + 'routes'.