### PR TITLE
fix: static file routing and TS type only (safe)

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,8 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    // allowedHosts expects true | string[] | undefined; keep it enabled as true
+    allowedHosts: true as const,
   };
 
   const vite = await createViteServer({

--- a/vercel.json
+++ b/vercel.json
@@ -24,6 +24,7 @@
     }
   ],
   "routes": [
+    { "handle": "filesystem" },
     {
       "src": "/api/(.*)",
       "dest": "server/index.ts"


### PR DESCRIPTION
- Vercel routes: handle filesystem before fallback to /index.html para servir assets con MIME correcto.\n- TS dev type-only fix: allowedHosts typed as const.\nNo cambia DB ni lógica de backend.