### PR TITLE
fix: replace @shared alias with relative imports for serverless

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -2,7 +2,7 @@
 import { Pool, neonConfig } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import ws from "ws";
-import * as schema from "@shared/schema";
+import * as schema from "../shared/schema.js";
 
 neonConfig.webSocketConstructor = ws;
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@ import type { Express, Request, Response, NextFunction } from "express";
 import { createServer, type Server } from "http";
 import { z } from "zod";
 import { storage } from "./storage.js";
-import { insertContactMessageSchema } from "@shared/schema";
+import { insertContactMessageSchema } from "../shared/schema.js";
 import { ZodError } from "zod";
 import { sendContactNotification } from "./services/mail.js";
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -8,7 +8,7 @@ import {
   type InsertChassisModel,
   type ContactMessage,
   type InsertContactMessage
-} from "@shared/schema";
+} from "../shared/schema.js";
 import { db } from "./db.js";
 import { eq, ilike, and, or } from "drizzle-orm";
 


### PR DESCRIPTION
Vercel serverless no resuelve alias de TS en runtime ESM. Se cambian a imports relativos '../shared/*.js'. Sin cambios en DB.